### PR TITLE
Serialize drive_change workflow executions

### DIFF
--- a/.github/workflows/invoice-renamer.yml
+++ b/.github/workflows/invoice-renamer.yml
@@ -5,7 +5,7 @@ on:
     types: [drive_change]
   workflow_dispatch: {}
 
-# ensure only one run; newer dispatch cancels older in-flight runs
+# Ensure only one run does work at a time; new dispatches wait for earlier runs.
 concurrency:
   group: invoice-renamer-drive-change
   cancel-in-progress: false
@@ -17,6 +17,32 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Wait for earlier drive_change runs to finish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_FILE: invoice-renamer.yml
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          echo "Checking for earlier workflow runs before continuing..."
+          attempts=0
+          while true; do
+            older=$(gh api repos/${GITHUB_REPOSITORY}/actions/workflows/${WORKFLOW_FILE}/runs \
+              -F per_page=100 \
+              --jq '.workflow_runs[] | select((.status=="in_progress" or .status=="queued" or .status=="waiting") and .run_number < ($env.RUN_NUMBER|tonumber)) | .id' \
+              | head -n1)
+            if [ -z "$older" ]; then
+              echo "No earlier runs are active; continuing."
+              break
+            fi
+            attempts=$((attempts + 1))
+            if [ "$attempts" -ge 40 ]; then
+              echo "Timed out waiting for earlier runs after $attempts checks." >&2
+              exit 1
+            fi
+            echo "Earlier run $older still active. Waiting 30s before rechecking..."
+            sleep 30
+          done
 
       # --- Restore the last startPageToken so we only process NEW changes
       - name: Restore Drive change token

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,18 @@
+# Code Review: `process_invoices.py`
+
+## 1. OCR confidence averaging always zero
+In `ocr_with_confidence`, the confidence values returned by Tesseract are string
+representations of numbers. The current comprehension only accepts numeric
+instances (`int`/`float`), so it drops every value, which forces `avg` to be `0`
+and triggers the "low confidence" retry logic for every document. This turns the
+adaptive preprocessing into the default path and makes the confidence metric
+meaningless. Convert the confidence entries with `float(c)` (skipping `-1`) before
+computing the average.
+
+## 2. Minor cleanups
+* `download_first_page` initialises `downloader = next_chunk = None` but `next_chunk`
+is unused afterwards. Drop the assignment to avoid confusion.
+* `unique_name_in_folder` always splits the original `base` instead of the
+current `name` when adding suffixes. This works for the current pattern but would
+break for names that already include a suffix (e.g. `NNNN_000001_2.pdf`). Split
+the evolving `name` instead to keep the logic robust if the function is reused.


### PR DESCRIPTION
## Summary
- add an explicit wait step so repository_dispatch events queue behind older drive_change runs
- document that concurrency keeps one run active at a time without cancelling newer ones

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690f0d3f1b948324b34a6cc441c85e2b)