### PR TITLE
Run invoice-renamer on a 10-minute schedule instead of dispatch triggers

### DIFF
--- a/.github/workflows/invoice-renamer.yml
+++ b/.github/workflows/invoice-renamer.yml
@@ -1,11 +1,9 @@
 name: drive_change
 
 on:
-  repository_dispatch:
-    types: [drive_change]
-  workflow_dispatch: {}
+  schedule: [{ cron: "*/10 * * * *" }]
 
-# ensure only one run; newer dispatch cancels older in-flight runs
+# ensure only one scheduled run at a time
 concurrency:
   group: invoice-renamer-drive-change
   cancel-in-progress: false


### PR DESCRIPTION
### Motivation
- Replace manual and repository dispatch triggers with a periodic scheduler so the workflow polls Drive changes every 10 minutes.

### Description
- Update `.github/workflows/invoice-renamer.yml` to remove `repository_dispatch` and `workflow_dispatch` and add a `schedule` entry with `cron: "*/10 * * * *"`, and update the concurrency comment to reflect scheduled runs.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a325911cf348324b9694bc2d18173df)