### PR TITLE
Run invoice-renamer workflow on a 10-minute cron schedule

### DIFF
--- a/.github/workflows/invoice-renamer.yml
+++ b/.github/workflows/invoice-renamer.yml
@@ -1,11 +1,11 @@
 name: drive_change
 
 on:
-  repository_dispatch:
-    types: [drive_change]
-  workflow_dispatch: {}
+  schedule:
+    # Run every 10 minutes, offset from :00 to avoid GitHub's busiest cron minute.
+    - cron: "3,13,23,33,43,53 * * * *"
 
-# ensure only one run; newer dispatch cancels older in-flight runs
+# ensure only one scheduled run at a time
 concurrency:
   group: invoice-renamer-drive-change
   cancel-in-progress: false


### PR DESCRIPTION
### Motivation
- Replace manual dispatch triggers with a periodic schedule so Drive changes are processed automatically and avoid GitHub's busiest cron minute by offsetting the run times.

### Description
- Update `.github/workflows/invoice-renamer.yml` to replace `repository_dispatch` and `workflow_dispatch` with a `schedule` using cron `"3,13,23,33,43,53 * * * *"` and adjust the comment to reflect scheduled runs while leaving the `concurrency` block intact.

### Testing
- No automated tests were executed for this workflow file change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a325911cf348324b9694bc2d18173df)