### PR TITLE
Separate Drive change processing schedule and make invoice-renamer a reusable workflow

### DIFF
--- a/.github/workflows/drive-watch-renew.yml
+++ b/.github/workflows/drive-watch-renew.yml
@@ -2,13 +2,23 @@
 name: Drive Watch Renew
 
 on:
-  schedule: [{ cron: "*/60 * * * *" }]
+  schedule:
+    # Run Drive change processing every 10 minutes from this already-active scheduled workflow.
+    - cron: "3,13,23,33,43,53 * * * *"
+    # Renew the Drive watch channel hourly, offset from the Drive change processing minutes.
+    - cron: "7 * * * *"
   workflow_dispatch: {}
 
 permissions: { contents: read }
 
 jobs:
+  process_drive_changes:
+    if: ${{ github.event_name == 'schedule' && github.event.schedule == '3,13,23,33,43,53 * * * *' }}
+    uses: ./.github/workflows/invoice-renamer.yml
+    secrets: inherit
+
   renew:
+    if: ${{ github.event_name != 'schedule' || github.event.schedule == '7 * * * *' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/invoice-renamer.yml
+++ b/.github/workflows/invoice-renamer.yml
@@ -1,11 +1,9 @@
 name: drive_change
 
 on:
-  repository_dispatch:
-    types: [drive_change]
-  workflow_dispatch: {}
+  workflow_call:
 
-# ensure only one run; newer dispatch cancels older in-flight runs
+# ensure only one scheduled or called run at a time
 concurrency:
   group: invoice-renamer-drive-change
   cancel-in-progress: false


### PR DESCRIPTION
### Motivation
- Run Drive change processing more frequently while keeping the Drive watch channel renewal on an hourly cadence to reduce latency between changes and processing. 
- Offset the renewal minute so the watch stop/create always runs separately from the frequent change-processing runs. 
- Allow the existing invoice renaming logic to be invoked as a reusable workflow rather than relying on `repository_dispatch` events.

### Description
- Updated `.github/workflows/drive-watch-renew.yml` to replace the single hourly cron with two scheduled entries: `3,13,23,33,43,53 * * * *` for frequent Drive change processing and `7 * * * *` for hourly watch channel renewal. 
- Added a `process_drive_changes` job that conditionally calls the reusable workflow at the frequent schedule using `uses: ./.github/workflows/invoice-renamer.yml` and added conditional execution guards for both jobs. 
- Modified the `renew` job condition to run only on non-schedule events or on the hourly `7 * * * *` schedule to avoid overlapping with processing runs. 
- Converted `.github/workflows/invoice-renamer.yml` from triggers (`repository_dispatch` and `workflow_dispatch`) to `workflow_call` so it can be invoked as a reusable workflow while keeping the existing concurrency group and caching/token restore steps. 

### Testing
- No automated CI tests were triggered for these workflow-only changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a325911cf348324b9694bc2d18173df)