### PR TITLE
Revert workflow changes from PRs #5–#8

### DIFF
--- a/.github/workflows/drive-watch-renew.yml
+++ b/.github/workflows/drive-watch-renew.yml
@@ -2,23 +2,13 @@
 name: Drive Watch Renew
 
 on:
-  schedule:
-    # Run Drive change processing every 10 minutes from this already-active scheduled workflow.
-    - cron: "3,13,23,33,43,53 * * * *"
-    # Renew the Drive watch channel hourly, offset from the Drive change processing minutes.
-    - cron: "7 * * * *"
+  schedule: [{ cron: "*/60 * * * *" }]
   workflow_dispatch: {}
 
 permissions: { contents: read }
 
 jobs:
-  process_drive_changes:
-    if: ${{ github.event_name == 'schedule' && github.event.schedule == '3,13,23,33,43,53 * * * *' }}
-    uses: ./.github/workflows/invoice-renamer.yml
-    secrets: inherit
-
   renew:
-    if: ${{ github.event_name != 'schedule' || github.event.schedule == '7 * * * *' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/invoice-renamer.yml
+++ b/.github/workflows/invoice-renamer.yml
@@ -1,9 +1,11 @@
 name: drive_change
 
 on:
-  workflow_call:
+  repository_dispatch:
+    types: [drive_change]
+  workflow_dispatch: {}
 
-# ensure only one scheduled or called run at a time
+# ensure only one run; newer dispatch cancels older in-flight runs
 concurrency:
   group: invoice-renamer-drive-change
   cancel-in-progress: false


### PR DESCRIPTION
### Motivation
- Undo the workflow edits introduced earlier today that altered scheduled runs and cross-workflow invocation. 
- Restore the Drive watch renew and drive_change workflows to their previous trigger/scheduling semantics so the renew job runs on its prior cadence and the change processor only runs via dispatch. 

### Description
- Reverted changes in `.github/workflows/drive-watch-renew.yml` to remove the additional scheduled triggers and the `process_drive_changes` job, and keep only the `renew` job with its prior schedule. 
- Restored `.github/workflows/invoice-renamer.yml` to use `repository_dispatch` (type `drive_change`) plus `workflow_dispatch` instead of `workflow_call`. 
- Updated comments and concurrency notes in `invoice-renamer.yml` to reflect that newer dispatches cancel older in-flight runs while keeping `cancel-in-progress: false`. 

### Testing
- Repository status and diff checks were run and show the two workflow files were updated. 
- Diff summary reports `2 files changed, 5 insertions(+), 13 deletions(-)` and the revert applied cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a32795a2dc48324b0dacbe3cca103a4)