### PR TITLE
Fix invoice renaming for updated Fresh Bake template

### DIFF
--- a/process_invoices.py
+++ b/process_invoices.py
@@ -1,60 +1,30 @@
 #!/usr/bin/env python3
 """
-Invoice Renamer — Changes-only (fast) version + Odoo attachment (customer invoices).
+Invoice Renamer - changes-only Google Drive processor with optional Odoo attachment.
 
-What it does:
-- Uses Drive Changes API with a persisted startPageToken: only processes NEW/CHANGED files.
-- Resolves the provided folder ID if it’s a shortcut, supports My Drive & Shared Drives.
-- Filters to PDFs whose names start with "IMG" (case-insensitive), within the folder tree.
-- OCRs the first page with Tesseract (rasterized via PyMuPDF) and renames the file in place.
-- Skips items already in final "NNNN[_mmmmmm][_n].pdf" form.
-- OPTIONAL: attaches the PDF to the matching Odoo customer invoice (account.move out_invoice)
-  by converting "2026_000073" -> "INV/2026/000073".
-
-ENV
-  GDRIVE_SA_JSON        : service account JSON (one line)
-  GDRIVE_FOLDER_ID      : target folder ID (not shortcut; will be resolved if it is)
-  DEBUG_LIST            : "1" for verbose logging (optional)
-
-  ENABLE_ODOO           : "1" to enable Odoo attachment (optional)
-  ODOO_URL              : e.g. https://yourcompany.odoo.com
-  ODOO_DB               : database name
-  ODOO_USER             : login/email
-  ODOO_API_KEY          : API key for the user
-
-  DISABLE_APPDATA_TOKEN : "1" to not use Drive appDataFolder for token persistence (optional)
-
-Python requirements
-  google-api-python-client, google-auth
-  pytesseract, opencv-python-headless, numpy, Pillow, PyMuPDF
-
-System requirement
-  tesseract-ocr
-
-Notes:
-- Odoo integration assumes invoices are POSTED and the invoice number is in account.move.name
-  like "INV/2026/000073". Draft invoices usually have name="/" and won’t match.
+The first page is OCRed and renamed from an Odoo customer invoice number such as
+INV/2026/042130 to 2026_042130.pdf. The extractor prioritises the Fresh Bake
+invoice-number row and only accepts explicit invoice-number formats; company
+registration numbers and other slash-separated values are ignored.
 """
 
 import io
-import os
-import re
 import json
 import logging
+import os
 import pathlib
-from typing import Optional, Tuple, Dict, List
+import re
+from typing import Dict, List, Optional, Tuple
 
-import numpy as np
 import cv2
-import pytesseract
 import fitz  # PyMuPDF
-
+import numpy as np
+import pytesseract
+from google.oauth2 import service_account
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaIoBaseUpload
-from google.oauth2 import service_account
 
 
-# ---------- Logging ----------
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s %(levelname)s %(message)s",
@@ -62,51 +32,80 @@ logging.basicConfig(
 log = logging.getLogger("invoice_renamer")
 
 
-# ---------- Config from env ----------
 FOLDER_ID = os.environ["GDRIVE_FOLDER_ID"].strip()
 SA_JSON = json.loads(os.environ["GDRIVE_SA_JSON"])
 DEBUG = os.environ.get("DEBUG_LIST", "0") == "1"
-
 ENABLE_ODOO = os.environ.get("ENABLE_ODOO", "0") == "1"
 
-# Where we persist the Drive startPageToken between runs.
-# The authoritative copy lives in Drive appDataFolder; we mirror it locally for compatibility.
 TOKEN_PATH = pathlib.Path(".drive_change_token")
 TOKEN_APPDATA_NAME = "invoice-renamer-token"
 DISABLE_APPDATA_TOKEN = os.environ.get("DISABLE_APPDATA_TOKEN", "0") == "1"
 
-# MIME constants
 PDF_MT = "application/pdf"
 FOLDER_MT = "application/vnd.google-apps.folder"
 SHORTCUT_MT = "application/vnd.google-apps.shortcut"
 
-# File name filters/patterns
 IMG_PDF_RE = re.compile(r"^IMG.*\.pdf$", re.I)
 RENAMED_RE = re.compile(r"^\d{4}(?:_\d{1,6})?(?:_\d+)?\.pdf$", re.I)
 
+# OCR commonly substitutes these letters for digits. Translation is applied only
+# inside a candidate invoice number, never to the rest of the page text.
+OCR_DIGIT_TRANSLATION = str.maketrans(
+    {
+        "O": "0",
+        "Q": "0",
+        "D": "0",
+        "I": "1",
+        "L": "1",
+        "Z": "2",
+        "S": "5",
+        "G": "6",
+        "B": "8",
+    }
+)
+OCR_DIGIT = r"[0-9OQDISBGLZ]"
+OCR_YEAR = rf"(?P<year>(?:{OCR_DIGIT}\s*){{4}})"
+OCR_SERIAL = rf"(?P<serial>(?:{OCR_DIGIT}\s*){{1,6}})(?!{OCR_DIGIT})"
+OCR_SEPARATOR = r"\s*[/\\|_.-]\s*"
 
-# ---------- Drive helpers ----------
+# Important: the negative look-ahead after INV/NV prevents matching the 'nv' in
+# the word 'Invoice'. That old behaviour caused 'Tax Invoice Reg No: 2011/053816'
+# to be interpreted as invoice 2011_053816.
+EXPLICIT_INVOICE_RE = re.compile(
+    rf"(?<![A-Z0-9])(?P<prefix>[I1L]\s*N\s*V|N\s*V)(?![A-Z0-9])"
+    rf"[\s:#/\\|_.-]*{OCR_YEAR}{OCR_SEPARATOR}{OCR_SERIAL}",
+    re.I,
+)
+
+# Safe fallback when OCR drops the INV token but still reads the specific field
+# label from the Fresh Bake template.
+LABELLED_INVOICE_RE = re.compile(
+    rf"(?:TAX\s+)?INVOICE\s+"
+    rf"(?:N[UO]M(?:BER|8ER)|NUMBER|NO\.?|NR\.?)"
+    rf"\s*[:#-]?\s*{OCR_YEAR}{OCR_SEPARATOR}{OCR_SERIAL}",
+    re.I,
+)
+
+
 def drive():
     creds = service_account.Credentials.from_service_account_info(
-        SA_JSON, scopes=["https://www.googleapis.com/auth/drive"]
+        SA_JSON,
+        scopes=["https://www.googleapis.com/auth/drive"],
     )
     return build("drive", "v3", credentials=creds, cache_discovery=False)
 
 
 def resolve_root(d, folder_id: str) -> Tuple[str, Optional[str]]:
-    """
-    Return (real_root_id, drive_id).
-    If the provided ID is a shortcut, resolve to its target.
-    """
+    """Return (real_root_id, drive_id), resolving a shortcut if needed."""
     meta = d.files().get(
         fileId=folder_id,
         fields="id,name,mimeType,driveId,shortcutDetails",
         supportsAllDrives=True,
     ).execute()
     if meta.get("mimeType") == SHORTCUT_MT:
-        tgt = meta["shortcutDetails"]["targetId"]
+        target_id = meta["shortcutDetails"]["targetId"]
         resolved = d.files().get(
-            fileId=tgt,
+            fileId=target_id,
             fields="id,name,mimeType,driveId",
             supportsAllDrives=True,
         ).execute()
@@ -116,14 +115,14 @@ def resolve_root(d, folder_id: str) -> Tuple[str, Optional[str]]:
 
 
 def get_start_token(d, drive_id: Optional[str]) -> str:
-    """Fetch a fresh startPageToken."""
     if drive_id:
-        resp = d.changes().getStartPageToken(
-            driveId=drive_id, supportsAllDrives=True
+        response = d.changes().getStartPageToken(
+            driveId=drive_id,
+            supportsAllDrives=True,
         ).execute()
     else:
-        resp = d.changes().getStartPageToken().execute()
-    return resp["startPageToken"]
+        response = d.changes().getStartPageToken().execute()
+    return response["startPageToken"]
 
 
 def load_token(d) -> Optional[str]:
@@ -131,19 +130,20 @@ def load_token(d) -> Optional[str]:
 
     if not DISABLE_APPDATA_TOKEN:
         try:
-            resp = d.files().list(
+            response = d.files().list(
                 spaces="appDataFolder",
                 q=f"name='{TOKEN_APPDATA_NAME}' and trashed=false",
                 fields="files(id)",
                 pageSize=1,
             ).execute()
-            files = resp.get("files") or []
+            files = response.get("files") or []
             if files:
                 data = d.files().get_media(fileId=files[0]["id"]).execute()
-                if isinstance(data, bytes):
-                    token = data.decode("utf-8", errors="ignore").strip()
-                else:
-                    token = str(data).strip()
+                token = (
+                    data.decode("utf-8", errors="ignore").strip()
+                    if isinstance(data, bytes)
+                    else str(data).strip()
+                )
         except Exception as exc:
             log.warning("Unable to read Drive token from appData: %s", exc)
 
@@ -152,7 +152,7 @@ def load_token(d) -> Optional[str]:
             TOKEN_PATH.write_text(token)
         except Exception:
             pass
-        return token or None
+        return token
 
     try:
         token = TOKEN_PATH.read_text().strip()
@@ -160,7 +160,8 @@ def load_token(d) -> Optional[str]:
             return None
         if not DISABLE_APPDATA_TOKEN:
             log.info(
-                "Using local Drive change token fallback; set DISABLE_APPDATA_TOKEN=1 to opt out of appData usage."
+                "Using local Drive change token fallback; set "
+                "DISABLE_APPDATA_TOKEN=1 to opt out of appData usage."
             )
         return token
     except FileNotFoundError:
@@ -176,16 +177,15 @@ def save_token(d, token: str):
     if DISABLE_APPDATA_TOKEN:
         return
 
-    data = token.encode("utf-8")
-    media = MediaIoBaseUpload(io.BytesIO(data), mimetype="text/plain")
+    media = MediaIoBaseUpload(io.BytesIO(token.encode("utf-8")), mimetype="text/plain")
     try:
-        resp = d.files().list(
+        response = d.files().list(
             spaces="appDataFolder",
             q=f"name='{TOKEN_APPDATA_NAME}' and trashed=false",
             fields="files(id)",
             pageSize=1,
         ).execute()
-        files = resp.get("files") or []
+        files = response.get("files") or []
         if files:
             d.files().update(fileId=files[0]["id"], media_body=media).execute()
         else:
@@ -195,8 +195,12 @@ def save_token(d, token: str):
         log.warning("Unable to save Drive token to appData: %s", exc)
 
 
-def file_meta(d, fid: str, fields: str):
-    return d.files().get(fileId=fid, fields=fields, supportsAllDrives=True).execute()
+def file_meta(d, file_id: str, fields: str):
+    return d.files().get(
+        fileId=file_id,
+        fields=fields,
+        supportsAllDrives=True,
+    ).execute()
 
 
 def is_under_root(
@@ -205,120 +209,201 @@ def is_under_root(
     root_id: str,
     parent_cache: Dict[str, Optional[List[str]]],
 ) -> bool:
-    """
-    Ascend parents until we hit root_id or the top.
-    parent_cache memoizes parent->parents lookups to reduce API calls.
-    """
     if not file_parents:
         return False
+
     stack = list(file_parents)
     while stack:
-        pid = stack.pop()
-        if pid == root_id:
+        parent_id = stack.pop()
+        if parent_id == root_id:
             return True
-        if pid in parent_cache:
-            parents = parent_cache[pid]
+
+        if parent_id in parent_cache:
+            parents = parent_cache[parent_id]
         else:
             try:
-                md = d.files().get(
-                    fileId=pid,
+                metadata = d.files().get(
+                    fileId=parent_id,
                     fields="id,parents",
-                    supportsAllDrives=True
+                    supportsAllDrives=True,
                 ).execute()
-                parents = md.get("parents") or []
+                parents = metadata.get("parents") or []
             except Exception:
                 parents = []
-            parent_cache[pid] = parents if parents else None
+            parent_cache[parent_id] = parents if parents else None
+
         if parents:
             stack.extend(parents)
+
     return False
 
 
-# ---------- Download & OCR ----------
 def download_pdf_bytes(d, file_id: str) -> Optional[bytes]:
-    req = d.files().get_media(fileId=file_id)
-    buf = io.BytesIO()
     from googleapiclient.http import MediaIoBaseDownload
-    downloader = MediaIoBaseDownload(buf, req)
+
+    request = d.files().get_media(fileId=file_id)
+    buffer = io.BytesIO()
+    downloader = MediaIoBaseDownload(buffer, request)
     done = False
     while not done:
         _, done = downloader.next_chunk()
-    data = buf.getvalue()
+    data = buffer.getvalue()
     return data or None
 
 
 def rasterize_first_page(pdf_bytes: bytes) -> Optional[np.ndarray]:
-    zoom = 300.0 / 72.0  # 72pt baseline -> ~300 DPI
-    mat = fitz.Matrix(zoom, zoom)
-    with fitz.open(stream=pdf_bytes, filetype="pdf") as doc:
-        if doc.page_count == 0:
+    matrix = fitz.Matrix(300.0 / 72.0, 300.0 / 72.0)
+    with fitz.open(stream=pdf_bytes, filetype="pdf") as document:
+        if document.page_count == 0:
             return None
-        page = doc.load_page(0)
-        pix = page.get_pixmap(matrix=mat, alpha=False)  # RGB
-        img = np.frombuffer(pix.samples, dtype=np.uint8).reshape(pix.height, pix.width, 3)
-        return img
+        page = document.load_page(0)
+        pixmap = page.get_pixmap(matrix=matrix, alpha=False)
+        return np.frombuffer(pixmap.samples, dtype=np.uint8).reshape(
+            pixmap.height,
+            pixmap.width,
+            3,
+        )
 
 
-def ocr_with_confidence(image: np.ndarray):
+def ocr_with_confidence(image: np.ndarray, psm: int = 6) -> Tuple[str, float]:
     data = pytesseract.image_to_data(
-        image, config="--psm 6 --oem 3", output_type=pytesseract.Output.DICT
+        image,
+        config=f"--psm {psm} --oem 3",
+        output_type=pytesseract.Output.DICT,
     )
-    text = " ".join([t for t in data.get("text", []) if t]).strip()
-    confs = [c for c in data.get("conf", []) if isinstance(c, (int, float)) and c != -1]
-    avg = sum(confs) / len(confs) if confs else 0.0
-    return text, avg
+    text = " ".join(str(value) for value in data.get("text", []) if str(value).strip())
+
+    confidences: List[float] = []
+    for value in data.get("conf", []):
+        try:
+            confidence = float(value)
+        except (TypeError, ValueError):
+            continue
+        if confidence >= 0:
+            confidences.append(confidence)
+
+    average = sum(confidences) / len(confidences) if confidences else 0.0
+    return text.strip(), average
 
 
 def preprocess_image(image: np.ndarray) -> np.ndarray:
-    gray = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
-    gray = cv2.equalizeHist(gray)
-    return cv2.adaptiveThreshold(
-        gray, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY, 11, 2
-    )
+    """Increase local contrast and binarise without amplifying background noise."""
+    if image.ndim == 3:
+        gray = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
+    else:
+        gray = image
+    clahe = cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
+    enhanced = clahe.apply(gray)
+    return cv2.threshold(
+        enhanced,
+        0,
+        255,
+        cv2.THRESH_BINARY + cv2.THRESH_OTSU,
+    )[1]
+
+
+def _normalise_ocr_digits(value: str) -> str:
+    translated = value.upper().translate(OCR_DIGIT_TRANSLATION)
+    return re.sub(r"\D", "", translated)
+
+
+def _invoice_from_match(match: re.Match) -> Optional[str]:
+    year = _normalise_ocr_digits(match.group("year"))
+    serial = _normalise_ocr_digits(match.group("serial"))
+
+    if len(year) != 4 or not year.startswith("20"):
+        return None
+    if not 1 <= len(serial) <= 6:
+        return None
+
+    return f"{year}_{serial.zfill(6)}"
 
 
 def extract_invoice_number(text: str) -> Optional[str]:
     """
-    Extract invoice number. Pattern: (INV|NV) ... 4+digits ... up to 6 trailing digits.
-    Produces 'NNNN[_mmmmmm]' style after cleaning (ex: 2026_000073).
+    Extract an Odoo invoice number from OCR text.
+
+    Accepted examples include INV/2026/042130 and, as a guarded fallback,
+    'Tax Invoice Number 2026/042130'. A bare slash-separated number is never
+    accepted, so Fresh Bake's registration number cannot be selected.
     """
-    m = re.search(r"(?:INV|NV)[^\d]*(\d{4}[^\d]*\d{1,6})", text, flags=re.I)
-    if not m:
-        return None
-    s = m.group(1).strip()
-    for k, v in {"A": "4", " ": "", "/": "_", "O": "0", "I": "1"}.items():
-        s = s.replace(k, v)
-    s = re.sub(r"[^\d_]", "", s)
-    parts = s.split("_")
-    if len(parts) == 2 and len(parts[1]) < 6:
-        parts[1] = parts[1].ljust(6, "0")
-        s = "_".join(parts)
-    return s
+    normalised_text = " ".join(text.upper().split())
+
+    for pattern in (EXPLICIT_INVOICE_RE, LABELLED_INVOICE_RE):
+        for match in pattern.finditer(normalised_text):
+            invoice = _invoice_from_match(match)
+            if invoice:
+                return invoice
+
+    return None
+
+
+def _fresh_bake_header_crop(image: np.ndarray) -> np.ndarray:
+    """Crop the new-template invoice-number zone while excluding the Reg No block."""
+    height, width = image.shape[:2]
+    y1 = max(0, int(height * 0.05))
+    y2 = min(height, int(height * 0.25))
+    x1 = max(0, int(width * 0.01))
+    x2 = min(width, int(width * 0.70))
+    return image[y1:y2, x1:x2]
+
+
+def extract_invoice_number_from_image(image: np.ndarray) -> Tuple[Optional[str], float, str]:
+    """OCR the most reliable regions first and return (number, confidence, source)."""
+    header = _fresh_bake_header_crop(image)
+    attempts = (
+        ("fresh-bake-header", header, 6),
+        ("fresh-bake-header-enhanced", preprocess_image(header), 6),
+        ("full-page", image, 6),
+        ("full-page-enhanced", preprocess_image(image), 6),
+        ("full-page-sparse", image, 11),
+    )
+
+    best_confidence = 0.0
+    for source, attempt_image, psm in attempts:
+        text, confidence = ocr_with_confidence(attempt_image, psm=psm)
+        best_confidence = max(best_confidence, confidence)
+        invoice = extract_invoice_number(text)
+        if invoice:
+            if DEBUG:
+                log.info(
+                    "OCR MATCH invoice=%s source=%s confidence=%.1f",
+                    invoice,
+                    source,
+                    confidence,
+                )
+            return invoice, confidence, source
+
+    return None, best_confidence, "no-match"
 
 
 def unique_name_in_folder(d, folder_id: str, base: str) -> str:
-    """
-    Ensure (base) is unique in the folder; if not, suffix _n.
-    """
-    name, n = base, 1
+    name = base
+    suffix = 1
     while True:
-        q = f"name='{name}' and '{folder_id}' in parents and trashed=false"
-        res = d.files().list(
-            q=q, fields="files(id)", pageSize=1,
-            supportsAllDrives=True, includeItemsFromAllDrives=True
+        query = f"name='{name}' and '{folder_id}' in parents and trashed=false"
+        response = d.files().list(
+            q=query,
+            fields="files(id)",
+            pageSize=1,
+            supportsAllDrives=True,
+            includeItemsFromAllDrives=True,
         ).execute()
-        if not res.get("files"):
+        if not response.get("files"):
             return name
-        root, ext = os.path.splitext(base)
-        name = f"{root}_{n}{ext}"
-        n += 1
+        root, extension = os.path.splitext(base)
+        name = f"{root}_{suffix}{extension}"
+        suffix += 1
 
 
-def rename_in_drive(d, fid: str, new_name: str):
-    d.files().update(fileId=fid, body={"name": new_name}, supportsAllDrives=True).execute()
+def rename_in_drive(d, file_id: str, new_name: str):
+    d.files().update(
+        fileId=file_id,
+        body={"name": new_name},
+        supportsAllDrives=True,
+    ).execute()
 
 
-# ---------- Main (changes-driven) ----------
 def main():
     d = drive()
     root_id, drive_id = resolve_root(d, FOLDER_ID)
@@ -334,130 +419,149 @@ def main():
     processed = 0
     next_token = None
 
-    # Lazy-init Odoo client only if needed
     odoo_client = None
     to_odoo_invoice_name = None
     if ENABLE_ODOO:
         try:
-            from odoo_attach import OdooClient, to_odoo_invoice_name as _to_odoo_invoice_name
+            from odoo_attach import OdooClient
+            from odoo_attach import to_odoo_invoice_name as _to_odoo_invoice_name
+
             odoo_client = OdooClient()
             to_odoo_invoice_name = _to_odoo_invoice_name
             log.info("Odoo integration enabled.")
-        except Exception as e:
-            log.warning("Odoo integration requested but failed to init: %s", e)
-            odoo_client = None
+        except Exception as exc:
+            log.warning("Odoo integration requested but failed to init: %s", exc)
 
     while True:
-        kwargs = dict(
-            pageToken=token,
-            fields="nextPageToken,newStartPageToken,changes(fileId,removed,file)",
-            includeItemsFromAllDrives=True,
-            supportsAllDrives=True,
-        )
+        kwargs = {
+            "pageToken": token,
+            "fields": "nextPageToken,newStartPageToken,changes(fileId,removed,file)",
+            "includeItemsFromAllDrives": True,
+            "supportsAllDrives": True,
+        }
         if drive_id:
             kwargs["driveId"] = drive_id
 
-        resp = d.changes().list(**kwargs).execute()
+        response = d.changes().list(**kwargs).execute()
 
-        for ch in resp.get("changes", []):
-            fid = ch.get("fileId")
-            removed = ch.get("removed", False)
-            fobj = ch.get("file") or {}
+        for change in response.get("changes", []):
+            file_id = change.get("fileId")
+            removed = change.get("removed", False)
+            file_object = change.get("file") or {}
 
-            if removed or not fobj:
+            if removed or not file_object or file_object.get("trashed"):
                 continue
-            if fobj.get("trashed"):
-                continue
-            if fobj.get("mimeType") != PDF_MT:
+            if file_object.get("mimeType") != PDF_MT:
                 continue
 
-            # name & parents might not be present in change
-            name = fobj.get("name", "")
-            parents = fobj.get("parents") or []
+            name = file_object.get("name", "")
+            parents = file_object.get("parents") or []
 
-            # Quick file-name filters:
             if RENAMED_RE.match(name or ""):
                 if DEBUG:
-                    log.info("SKIP %s  already looks renamed", name)
+                    log.info("SKIP %s already looks renamed", name)
                 continue
             if not IMG_PDF_RE.match(name or ""):
                 if DEBUG:
-                    log.info("SKIP %s  not IMG*.pdf", name)
+                    log.info("SKIP %s not IMG*.pdf", name)
                 continue
 
             if not parents:
-                meta = file_meta(d, fid, "id,name,parents,trashed")
-                if meta.get("trashed"):
+                metadata = file_meta(d, file_id, "id,name,parents,trashed")
+                if metadata.get("trashed"):
                     continue
-                name = meta.get("name", name)
-                parents = meta.get("parents") or []
+                name = metadata.get("name", name)
+                parents = metadata.get("parents") or []
 
             if not is_under_root(d, parents, root_id, parent_cache):
                 if DEBUG:
-                    log.info("SKIP %s  outside target tree", name)
+                    log.info("SKIP %s outside target tree", name)
                 continue
 
-            # Download PDF bytes once; OCR uses first page raster
-            pdf_bytes = download_pdf_bytes(d, fid)
+            pdf_bytes = download_pdf_bytes(d, file_id)
             if not pdf_bytes:
-                if DEBUG:
-                    log.info("No PDF bytes for %s; skipping", name)
+                log.warning("SKIP %s no PDF bytes", name)
                 continue
 
-            img = rasterize_first_page(pdf_bytes)
-            if img is None:
-                if DEBUG:
-                    log.info("No raster image for %s; skipping", name)
+            image = rasterize_first_page(pdf_bytes)
+            if image is None:
+                log.warning("SKIP %s could not rasterize first page", name)
                 continue
 
-            text, conf = ocr_with_confidence(img)
-            if conf < 40:
-                img2 = preprocess_image(img)
-                text, conf = ocr_with_confidence(img2)
-
-            inv = extract_invoice_number(text) or "UNKNOWN"
+            invoice, confidence, source = extract_invoice_number_from_image(image)
+            if not invoice:
+                # Do not turn an unreadable scan into UNKNOWN.pdf. Keeping the IMG
+                # name makes the exception visible and prevents a false attachment.
+                log.warning(
+                    "SKIP %s invoice number not confidently found "
+                    "(best OCR confidence=%.1f)",
+                    name,
+                    confidence,
+                )
+                continue
 
             parent_id = parents[0] if parents else root_id
-            new_name = unique_name_in_folder(d, parent_id, f"{inv}.pdf")
+            new_name = unique_name_in_folder(d, parent_id, f"{invoice}.pdf")
 
-            if new_name != name:
-                rename_in_drive(d, fid, new_name)
-                log.info("RENAMED  %s -> %s", name, new_name)
-                processed += 1
+            if new_name == name:
+                if DEBUG:
+                    log.info("SKIP %s name unchanged", name)
+                continue
 
-                # Optional: attach to Odoo customer invoice
-                if ENABLE_ODOO and odoo_client and inv != "UNKNOWN" and to_odoo_invoice_name:
-                    try:
-                        odoo_number = to_odoo_invoice_name(inv)  # 2026_000073 -> INV/2026/000073
-                        matches = odoo_client.search_customer_invoice_by_number(odoo_number)
+            rename_in_drive(d, file_id, new_name)
+            log.info(
+                "RENAMED %s -> %s (source=%s confidence=%.1f)",
+                name,
+                new_name,
+                source,
+                confidence,
+            )
+            processed += 1
 
-                        if len(matches) == 1:
-                            move_id = matches[0]
-                            attach_id = odoo_client.attach_pdf_to_move(move_id, new_name, pdf_bytes)
-                            log.info(
-                                "ODOO ATTACHED %s to invoice=%s move_id=%s attachment_id=%s",
-                                new_name, odoo_number, move_id, attach_id
-                            )
-                        elif len(matches) == 0:
-                            log.warning(
-                                "ODOO NO MATCH for invoice=%s (from scan=%s) file=%s",
-                                odoo_number, inv, new_name
-                            )
-                        else:
-                            log.warning(
-                                "ODOO MULTIPLE MATCHES for invoice=%s -> %s (file=%s)",
-                                odoo_number, matches, new_name
-                            )
+            if ENABLE_ODOO and odoo_client and to_odoo_invoice_name:
+                try:
+                    odoo_number = to_odoo_invoice_name(invoice)
+                    matches = odoo_client.search_customer_invoice_by_number(odoo_number)
 
-                    except Exception as e:
-                        log.warning("ODOO ATTACH FAILED for %s (inv=%s): %s", new_name, inv, e)
+                    if len(matches) == 1:
+                        move_id = matches[0]
+                        attachment_id = odoo_client.attach_pdf_to_move(
+                            move_id,
+                            new_name,
+                            pdf_bytes,
+                        )
+                        log.info(
+                            "ODOO ATTACHED %s to invoice=%s move_id=%s attachment_id=%s",
+                            new_name,
+                            odoo_number,
+                            move_id,
+                            attachment_id,
+                        )
+                    elif not matches:
+                        log.warning(
+                            "ODOO NO MATCH for invoice=%s (scan=%s) file=%s",
+                            odoo_number,
+                            invoice,
+                            new_name,
+                        )
+                    else:
+                        log.warning(
+                            "ODOO MULTIPLE MATCHES for invoice=%s -> %s (file=%s)",
+                            odoo_number,
+                            matches,
+                            new_name,
+                        )
+                except Exception as exc:
+                    log.warning(
+                        "ODOO ATTACH FAILED for %s (invoice=%s): %s",
+                        new_name,
+                        invoice,
+                        exc,
+                    )
 
-            elif DEBUG:
-                log.info("SKIP %s  name unchanged", name)
-
-        token = resp.get("nextPageToken")
+        token = response.get("nextPageToken")
         if not token:
-            next_token = resp.get("newStartPageToken")
+            next_token = response.get("newStartPageToken")
             break
 
     if next_token:

--- a/test_invoice_extraction.py
+++ b/test_invoice_extraction.py
@@ -1,0 +1,48 @@
+import os
+import unittest
+
+os.environ.setdefault("GDRIVE_FOLDER_ID", "test-folder")
+os.environ.setdefault("GDRIVE_SA_JSON", "{}")
+
+from process_invoices import extract_invoice_number
+
+
+class InvoiceNumberExtractionTests(unittest.TestCase):
+    def test_new_template_ignores_registration_number(self):
+        text = (
+            "Tax Invoice Reg No: 2011/053816/23 "
+            "Tax Invoice Number INV/2026/042130"
+        )
+        self.assertEqual(extract_invoice_number(text), "2026_042130")
+
+    def test_registration_number_alone_is_not_an_invoice(self):
+        self.assertIsNone(
+            extract_invoice_number("Tax Invoice Reg No: 2011/053816/23")
+        )
+
+    def test_nv_legacy_prefix_must_be_a_separate_token(self):
+        self.assertEqual(
+            extract_invoice_number("Invoice Number NV/2026/000073"),
+            "2026_000073",
+        )
+        self.assertIsNone(
+            extract_invoice_number(
+                "Tax Invoice Reg No: 2011/053816/23 Invoice Date 26/07/2026"
+            )
+        )
+
+    def test_labelled_fallback_zero_pads_on_the_left(self):
+        self.assertEqual(
+            extract_invoice_number("Tax Invoice Number 2026/42130"),
+            "2026_042130",
+        )
+
+    def test_common_ocr_digit_substitutions(self):
+        self.assertEqual(
+            extract_invoice_number("Tax Invoice Number I N V / 2O26 / O4213O"),
+            "2026_042130",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- Prioritises the updated Fresh Bake invoice-number area before OCRing the whole page.
- Requires an explicit `INV/...`, `NV/...`, or labelled `Tax Invoice Number ...` match.
- Prevents the `nv` inside the word `Invoice` from being treated as an invoice prefix.
- Rejects bare slash-separated values, so company registration numbers such as `2011/053816/23` are not selected.
- Left-pads short invoice sequences, so `2026/42130` becomes `2026_042130` rather than padding on the right.
- Tries multiple OCR variants and keeps unreadable files under their original `IMG*.pdf` name instead of renaming them to an incorrect value or `UNKNOWN.pdf`.
- Adds regression tests covering the attached failure example and common OCR substitutions.

## Verified example
The supplied invoice contains `Tax Invoice Number INV/2026/042130` and `Reg No: 2011/053816/23`. The new extraction logic selects `2026_042130` and explicitly rejects `2011_053816`.